### PR TITLE
Hora de fazer a paginação funcionar no front com URQL

### DIFF
--- a/client/src/pages/change-password/[token].tsx
+++ b/client/src/pages/change-password/[token].tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Link } from "@chakra-ui/react";
+import { Box, Link } from "@chakra-ui/react";
 import { Form, Formik } from "formik";
 import { NextPage } from "next";
 import { withUrqlClient } from "next-urql";
@@ -6,6 +6,7 @@ import NextLink from "next/link";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
 import InputField from "../../components/InputField";
+import StyledButton from "../../components/StyledButton";
 import Wrapper from "../../components/Wrapper";
 import { useChangePasswordMutation } from "../../generated/graphql";
 import createUrqlClient from "../../utils/createUrqlClient";
@@ -62,14 +63,7 @@ const ChangePassword: NextPage<{ token: string }> = () => {
               </Box>
             ) : null}
 
-            <Button
-              type="submit"
-              colorScheme="teal"
-              mt={4}
-              isLoading={isSubmitting}
-            >
-              Salvar
-            </Button>
+            <StyledButton isLoading={isSubmitting}>Salvar</StyledButton>
           </Form>
         )}
       </Formik>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,16 +1,19 @@
 import { Button, Flex, Heading } from "@chakra-ui/react";
 import { withUrqlClient } from "next-urql";
 import NextLink from "next/link";
+import { useState } from "react";
 import Layout from "../components/Layout";
 import PostList from "../components/PostList";
 import { usePostsQuery } from "../generated/graphql";
 import createUrqlClient from "../utils/createUrqlClient";
 
 const Index = () => {
+  const [variables, setVariables] = useState({
+    limit: 10,
+    cursor: null as string | null,
+  });
   const [{ data, fetching }] = usePostsQuery({
-    variables: {
-      limit: 10,
-    },
+    variables: variables,
   });
 
   if (!fetching && !data) {
@@ -52,6 +55,12 @@ const Index = () => {
             m={"auto"}
             my={8}
             isLoading={fetching}
+            onClick={() => {
+              setVariables({
+                limit: variables.limit,
+                cursor: data.posts[data.posts.length - 1].createdAt,
+              });
+            }}
           >
             Carregar mais...
           </Button>

--- a/client/src/utils/createUrqlClient.ts
+++ b/client/src/utils/createUrqlClient.ts
@@ -1,7 +1,12 @@
-import { cacheExchange, QueryInput } from "@urql/exchange-graphcache";
+import { cacheExchange, QueryInput, Resolver } from "@urql/exchange-graphcache";
 import { NextUrqlClientConfig } from "next-urql";
 import Router from "next/router";
-import { dedupExchange, errorExchange, fetchExchange } from "urql";
+import {
+  dedupExchange,
+  errorExchange,
+  fetchExchange,
+  stringifyVariables,
+} from "urql";
 import {
   LoginMutation,
   LogoutMutation,
@@ -10,6 +15,40 @@ import {
   RegisterMutation,
 } from "../generated/graphql";
 import { betterUpdateQuery } from "./betterUpdateQuery";
+
+const cursorPagination = (): Resolver => {
+  return (_parent, fieldArgs, cache, info) => {
+    const { parentKey: entityKey, fieldName } = info;
+
+    // isso aqui vai inspecionar tudo que tiver a palavra query (entityKey) no cache
+    const allFields = cache.inspectFields(entityKey);
+
+    // vai filtrar e deixar apenas apenas os fields em que o fieldName bater com fieldName (nesse caso, posts)
+    const fieldInfos = allFields.filter((info) => info.fieldName === fieldName);
+
+    // se não tiver dados, vai retornar undefined
+    const size = fieldInfos.length;
+    if (size === 0) {
+      return undefined;
+    }
+
+    // checar se os dados estão no cache e retornar eles do cache, combinando todos os dados de todas as páginas
+    const fieldKey = `${fieldName}(${stringifyVariables(fieldArgs)})`;
+
+    const isInCache = cache.resolve(entityKey, fieldKey); // se não tiver mais dados no cache, precisamos buscar no server
+    info.partial = !isInCache;
+
+    let results: string[] = [];
+
+    fieldInfos.forEach((fi) => {
+      const data = cache.resolve(entityKey, fi.fieldKey) as string[];
+      results.push(...data);
+    });
+
+    console.log("Results: ", results);
+    return results;
+  };
+};
 
 const createUrqlClient = (ssrExchange: any) => {
   return {
@@ -20,6 +59,11 @@ const createUrqlClient = (ssrExchange: any) => {
     exchanges: [
       dedupExchange,
       cacheExchange({
+        resolvers: {
+          Query: {
+            posts: cursorPagination(),
+          },
+        },
         updates: {
           Mutation: {
             logout: (_result, args, cache, info) => {


### PR DESCRIPTION
- Hora de fazer a paginação funcionar no front com URQL (diferente de como é com Apollo)
	- não dá para usar o simple pagination do URQL porque estamos usando paginação com cursor :/
	- vamos alterar o código do simple pagination do URQL :D (https://github.com/FormidableLabs/urql/blob/main/exchanges/graphcache/src/extras/simplePagination.ts)